### PR TITLE
Al cambiar la gravedad, el personaje rota sobre su eje

### DIFF
--- a/Jugador.gd
+++ b/Jugador.gd
@@ -19,6 +19,19 @@ var motion = Vector2(0, 0)
 var gravedad
 
 onready var Gravedad = preload("res://Gravedad.tscn")
+var sentidoADondeMiraSegunCaminar = Vector2(DERECHA, 0)
+var sentidoADondeMiraSegunGravedad = Vector2(DERECHA, 0)
+
+var rotacionAlEstarDeCabeza = PI
+
+enum {IZQUIERDA = -1, DERECHA = 1}
+
+func sentidoEnElQueMira():
+	return (sentidoADondeMiraSegunCaminar * sentidoADondeMiraSegunGravedad).x
+
+func mirarEnSentidoCorrecto():
+	sprite.flip_h = sentidoEnElQueMira() == DERECHA
+
 onready var Disparo = preload("res://Campo de gravedad.tscn")
 
 func _ready():
@@ -31,34 +44,33 @@ func _physics_process(delta):
 	efecto_gravitatorio()
 	var friction = false
 	current_main_action_cooldown = max(0, current_main_action_cooldown - delta)
-	
+
 	if Input.is_action_just_pressed("disparo"):
 		var disparo = Disparo.instance()
 		disparo.position = self.position
 		get_tree().get_current_scene().add_child(disparo)
-		if(sprite.flip_h):
-			disparo.motion = Vector2(1, 0)
-		else:
-			disparo.motion = Vector2(-1, 0)
-			
-	
+		disparo.motion = Vector2(sentidoADondeMiraSegunCaminar.x, 0)
+
 	if Input.is_action_pressed("accion_principal"):
 		if(current_main_action_cooldown <= 0):
 			nivel.invertirGravedadGlobal()
+			if(gravedad.esta_de_cabeza()):
+				self.rotation = -(PI * sentidoADondeMiraSegunCaminar.x)
+			rotacionAlEstarDeCabeza = PI * sentidoADondeMiraSegunCaminar.x
 			current_main_action_cooldown = main_action_cooldown
-	
+
 	if Input.is_action_pressed("ui_right"):
-		sprite.flip_h = true
+		sentidoADondeMiraSegunCaminar.x = DERECHA
 		animation.play("Walk")
 		motion.x = min(motion.x + ACELERATION, MAX_SPEED)
 	elif Input.is_action_pressed("ui_left"):
-		sprite.flip_h = false
+		sentidoADondeMiraSegunCaminar.x = IZQUIERDA
 		animation.play("Walk")
 		motion.x = max(motion.x - ACELERATION, -MAX_SPEED)
 	else:
 		animation.play("Idle")
 		friction = true
-		
+
 	if (is_on_floor() && !gravedad.esta_de_cabeza()) or (is_on_ceiling() && gravedad.esta_de_cabeza()):
 		if Input.is_action_pressed("accion_secundaria"):
 			motion.y += JUMP_H * gravedad.y()
@@ -68,13 +80,18 @@ func _physics_process(delta):
 		if friction == true:
 			motion.x = lerp(motion.x, 0, 0.01)
 
+	mirarEnSentidoCorrecto()
 	motion = move_and_slide(motion, UP)
 	rueda.te_moviste_a(self.position, sprite.flip_h)
 
 func efecto_gravitatorio():
 	motion.y += gravedad.gravedad()
-	self.scale.y = gravedad.y()
-	#self.flip_v = gravedad.esta_de_cabeza()
+	var tazaDeRotacion = 0.08
+	sentidoADondeMiraSegunGravedad.x = gravedad.y()
+	if(gravedad.esta_de_cabeza()):
+		self.rotation = lerp(self.rotation, rotacionAlEstarDeCabeza, tazaDeRotacion)
+	else:
+		self.rotation = lerp(self.rotation, 0, tazaDeRotacion)
 
 func mori():
 	get_tree().reload_current_scene()

--- a/Jugador.gd
+++ b/Jugador.gd
@@ -20,14 +20,13 @@ var gravedad
 
 onready var Gravedad = preload("res://Gravedad.tscn")
 var sentidoADondeMiraSegunCaminar = Vector2(DERECHA, 0)
-var sentidoADondeMiraSegunGravedad = Vector2(DERECHA, 0)
 
 var rotacionAlEstarDeCabeza = PI
 
 enum {IZQUIERDA = -1, DERECHA = 1}
 
 func sentidoEnElQueMira():
-	return (sentidoADondeMiraSegunCaminar * sentidoADondeMiraSegunGravedad).x
+	return (sentidoADondeMiraSegunCaminar * gravedad.y()).x
 
 func mirarEnSentidoCorrecto():
 	sprite.flip_h = sentidoEnElQueMira() == DERECHA
@@ -53,10 +52,10 @@ func _physics_process(delta):
 
 	if Input.is_action_pressed("accion_principal"):
 		if(current_main_action_cooldown <= 0):
-			nivel.invertirGravedadGlobal()
-			if(gravedad.esta_de_cabeza()):
-				self.rotation = -(PI * sentidoADondeMiraSegunCaminar.x)
 			rotacionAlEstarDeCabeza = PI * sentidoADondeMiraSegunCaminar.x
+			if(gravedad.esta_de_cabeza()):
+				self.rotation = rotacionAlEstarDeCabeza
+			nivel.invertirGravedadGlobal()
 			current_main_action_cooldown = main_action_cooldown
 
 	if Input.is_action_pressed("ui_right"):
@@ -87,7 +86,6 @@ func _physics_process(delta):
 func efecto_gravitatorio():
 	motion.y += gravedad.gravedad()
 	var tazaDeRotacion = 0.08
-	sentidoADondeMiraSegunGravedad.x = gravedad.y()
 	if(gravedad.esta_de_cabeza()):
 		self.rotation = lerp(self.rotation, rotacionAlEstarDeCabeza, tazaDeRotacion)
 	else:

--- a/Jugador.tscn
+++ b/Jugador.tscn
@@ -75,7 +75,6 @@ script = ExtResource( 6 )
 shape = SubResource( 4 )
 
 [node name="Camera2D" type="Camera2D" parent="."]
-position = Vector2( 220.251, -207.516 )
 current = true
 limit_left = 0
 limit_top = 0


### PR DESCRIPTION
# Que

Hacer que visualmente se vea rotar al personaje al cambiar la gravedad.

# Como

Agregados un par de vectores que van sobre el eje X e indican hacia donde mira el personaje. Uno cambia según el jugador aprieta izquierda o derecha y representa en que dirección se esta moviendo el personaje. Otra cambia cuando se invierte la gravedad.
De esta manera se puede calcular para donde está mirando el personaje en cada momento.

Por otro lado, agregué al efecto gravitatorio una interpolación con `lerp` sobre la rotación. Al usar la acción de cambiar la gravedad se fija hacia donde va a rotar: -PI o PI, la diferencia es si rota desde la izquierda o desde la derecha, que se decide según para donde está caminando.


https://user-images.githubusercontent.com/11432672/117559494-3786e800-b05c-11eb-8dd7-74c671d94e1b.mp4



