### PR TITLE
Jugador mide lo mismo que su area de colision

### DIFF
--- a/Jugador.gd
+++ b/Jugador.gd
@@ -19,6 +19,19 @@ var motion = Vector2(0, 0)
 var gravedad
 
 onready var Gravedad = preload("res://Gravedad.tscn")
+var sentidoADondeMiraSegunCaminar = Vector2(DERECHA, 0)
+var sentidoADondeMiraSegunGravedad = Vector2(DERECHA, 0)
+
+var rotacionAlEstarDeCabeza = PI
+
+enum {IZQUIERDA = -1, DERECHA = 1}
+
+func sentidoEnElQueMira():
+	return (sentidoADondeMiraSegunCaminar * sentidoADondeMiraSegunGravedad).x
+
+func mirarEnSentidoCorrecto():
+	sprite.flip_h = sentidoEnElQueMira() == DERECHA
+
 onready var Disparo = preload("res://Campo de gravedad.tscn")
 
 func _ready():
@@ -31,34 +44,33 @@ func _physics_process(delta):
 	efecto_gravitatorio()
 	var friction = false
 	current_main_action_cooldown = max(0, current_main_action_cooldown - delta)
-	
+
 	if Input.is_action_just_pressed("disparo"):
 		var disparo = Disparo.instance()
 		disparo.position = self.position
 		get_tree().get_current_scene().add_child(disparo)
-		if(sprite.flip_h):
-			disparo.motion = Vector2(1, 0)
-		else:
-			disparo.motion = Vector2(-1, 0)
-			
-	
+		disparo.motion = Vector2(sentidoADondeMiraSegunCaminar.x, 0)
+
 	if Input.is_action_pressed("accion_principal"):
 		if(current_main_action_cooldown <= 0):
 			nivel.invertirGravedadGlobal()
+			if(gravedad.esta_de_cabeza()):
+				self.rotation = -(PI * sentidoADondeMiraSegunCaminar.x)
+			rotacionAlEstarDeCabeza = PI * sentidoADondeMiraSegunCaminar.x
 			current_main_action_cooldown = main_action_cooldown
-	
+
 	if Input.is_action_pressed("ui_right"):
-		sprite.flip_h = true
+		sentidoADondeMiraSegunCaminar.x = DERECHA
 		animation.play("Walk")
 		motion.x = min(motion.x + ACELERATION, MAX_SPEED)
 	elif Input.is_action_pressed("ui_left"):
-		sprite.flip_h = false
+		sentidoADondeMiraSegunCaminar.x = IZQUIERDA
 		animation.play("Walk")
 		motion.x = max(motion.x - ACELERATION, -MAX_SPEED)
 	else:
 		animation.play("Idle")
 		friction = true
-		
+
 	if (is_on_floor() && !gravedad.esta_de_cabeza()) or (is_on_ceiling() && gravedad.esta_de_cabeza()):
 		if Input.is_action_pressed("accion_secundaria"):
 			motion.y += JUMP_H * gravedad.y()
@@ -68,13 +80,18 @@ func _physics_process(delta):
 		if friction == true:
 			motion.x = lerp(motion.x, 0, 0.01)
 
+	mirarEnSentidoCorrecto()
 	motion = move_and_slide(motion, UP)
 	rueda.te_moviste_a(self.position, sprite.flip_h)
 
 func efecto_gravitatorio():
 	motion.y += gravedad.gravedad()
-	self.scale.y = gravedad.y()
-	#self.flip_v = gravedad.esta_de_cabeza()
+	var tazaDeRotacion = 0.08
+	sentidoADondeMiraSegunGravedad.x = gravedad.y()
+	if(gravedad.esta_de_cabeza()):
+		self.rotation = lerp(self.rotation, rotacionAlEstarDeCabeza, tazaDeRotacion)
+	else:
+		self.rotation = lerp(self.rotation, 0, tazaDeRotacion)
 
 func mori():
 	get_tree().reload_current_scene()

--- a/Jugador.gd
+++ b/Jugador.gd
@@ -20,14 +20,13 @@ var gravedad
 
 onready var Gravedad = preload("res://Gravedad.tscn")
 var sentidoADondeMiraSegunCaminar = Vector2(DERECHA, 0)
-var sentidoADondeMiraSegunGravedad = Vector2(DERECHA, 0)
 
 var rotacionAlEstarDeCabeza = PI
 
 enum {IZQUIERDA = -1, DERECHA = 1}
 
 func sentidoEnElQueMira():
-	return (sentidoADondeMiraSegunCaminar * sentidoADondeMiraSegunGravedad).x
+	return (sentidoADondeMiraSegunCaminar * gravedad.y()).x
 
 func mirarEnSentidoCorrecto():
 	sprite.flip_h = sentidoEnElQueMira() == DERECHA
@@ -53,10 +52,10 @@ func _physics_process(delta):
 
 	if Input.is_action_pressed("accion_principal"):
 		if(current_main_action_cooldown <= 0):
-			nivel.invertirGravedadGlobal()
-			if(gravedad.esta_de_cabeza()):
-				self.rotation = -(PI * sentidoADondeMiraSegunCaminar.x)
 			rotacionAlEstarDeCabeza = PI * sentidoADondeMiraSegunCaminar.x
+			if(gravedad.esta_de_cabeza()):
+				self.rotation = rotacionAlEstarDeCabeza
+			nivel.invertirGravedadGlobal()
 			current_main_action_cooldown = main_action_cooldown
 
 	if Input.is_action_pressed("ui_right"):
@@ -87,7 +86,6 @@ func _physics_process(delta):
 func efecto_gravitatorio():
 	motion.y += gravedad.gravedad()
 	var tazaDeRotacion = 0.08
-	sentidoADondeMiraSegunGravedad.x = gravedad.y()
 	if(gravedad.esta_de_cabeza()):
 		self.rotation = lerp(self.rotation, rotacionAlEstarDeCabeza, tazaDeRotacion)
 	else:

--- a/Jugador.tscn
+++ b/Jugador.tscn
@@ -7,8 +7,9 @@
 [ext_resource path="res://Area de activacion.gd" type="Script" id=5]
 [ext_resource path="res://Area vulnerable.gd" type="Script" id=6]
 
-[sub_resource type="CircleShape2D" id=1]
-radius = 38.64
+[sub_resource type="CapsuleShape2D" id=1]
+radius = 19.4176
+height = 37.7636
 
 [sub_resource type="Animation" id=2]
 resource_name = "Idle"
@@ -42,8 +43,9 @@ tracks/0/keys = {
 "values": [ 0, 1, 2, 3 ]
 }
 
-[sub_resource type="CircleShape2D" id=4]
-radius = 36.9499
+[sub_resource type="CapsuleShape2D" id=4]
+radius = 20.4767
+height = 35.3597
 
 [sub_resource type="RectangleShape2D" id=5]
 extents = Vector2( 570.596, 407.585 )
@@ -57,8 +59,8 @@ position = Vector2( 0, 0.142761 )
 shape = SubResource( 1 )
 
 [node name="Sprite" type="Sprite" parent="."]
-position = Vector2( -0.139244, -75.685 )
-scale = Vector2( 5, 5 )
+position = Vector2( 0, -24 )
+scale = Vector2( 2.35135, 2.35135 )
 texture = ExtResource( 1 )
 hframes = 4
 
@@ -75,23 +77,26 @@ script = ExtResource( 6 )
 shape = SubResource( 4 )
 
 [node name="Camera2D" type="Camera2D" parent="."]
+visible = false
 current = true
 limit_left = 0
 limit_top = 0
 limit_bottom = 0
 
 [node name="Area de activacion" type="Area2D" parent="."]
+visible = false
 collision_layer = 8
 collision_mask = 0
 script = ExtResource( 5 )
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Area de activacion"]
+visible = false
 position = Vector2( 0.636414, 2.15909 )
 shape = SubResource( 5 )
 
 [node name="Rueda" type="Sprite" parent="."]
-position = Vector2( 0.057992, -0.0146952 )
-scale = Vector2( 0.596446, 0.596446 )
+position = Vector2( 0, 16.937 )
+scale = Vector2( 0.33158, 0.33158 )
 texture = ExtResource( 3 )
 script = ExtResource( 2 )
 

--- a/Jugador.tscn
+++ b/Jugador.tscn
@@ -75,7 +75,6 @@ script = ExtResource( 6 )
 shape = SubResource( 4 )
 
 [node name="Camera2D" type="Camera2D" parent="."]
-position = Vector2( 220.251, -207.516 )
 current = true
 limit_left = 0
 limit_top = 0


### PR DESCRIPTION
Al agregarle la rueda quedó muy alto el personaje, se que es temporal pero me parece que puede ser medio confuso que el area de colision no incluya al tipito, así que lo achiqué así queda con un area de colision parecida a la que tiene ahora, pero el sprite refleja eso.

Nota: este PR también tiene los cambios de #9, así se ve como gira también

https://user-images.githubusercontent.com/11432672/117598832-ee4b9c80-b11e-11eb-8393-47dab298cff3.mp4

